### PR TITLE
Fixed Handlebars template issue and added some styling for contributors'...

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,3 +52,12 @@ footer li {
 .lower {
   margin-top: 20px;
 }
+
+/* Projects */
+.contributors img {
+  width: 50px;
+}
+
+.contributor-owner img {
+  border: 1px solid darkgray;
+}

--- a/js/projects.js
+++ b/js/projects.js
@@ -2,14 +2,13 @@
 	
 	var cfapi = 'http://codeforamerica.org/api/organizations/Code-for-Sacramento/projects';
 
-	function displayProjects (data) {
+	var displayProjects = function (data) {
 
 		data.objects.forEach(function (project) {
 			
 			project.lastUpdateDaysFromNow = moment(project.last_updated).fromNow();
 		});
 		
-		//$("#projects").append(ich.projects({ projects: data.objects }));
 		var template = Handlebars.compile($("#project-template").html());
 		$("#projects").append(template({ projects: data.objects }));
 
@@ -17,7 +16,7 @@
 			$.getJSON(data.pages.next)
 			.done(displayProjects);
 		}
-	}
+	};
 	
 	$(document).ready(function () {
 		

--- a/projects/index.html
+++ b/projects/index.html
@@ -3,14 +3,16 @@ layout: default
 title: 'Our Projects'
 scripts: ['moment.js','handlebars.min.js','projects.js']
 ---	
+<script src="../js/handlebars.min.js"></script>
 <section class="container-fluid">
 	<div id="projects">
 	
 	</div>
 </section>
 
+{% raw %}
 <script id="project-template" type="text/x-handlebars-template">
-	{{#each projects}}
+  {{#each projects}}
 
 	<div class="row">
 		<div class="col-sm-12">
@@ -58,8 +60,9 @@ scripts: ['moment.js','handlebars.min.js','projects.js']
 	</div>
 	{{/each}}
 </script>
-	
-<!--<script src="../javascript/handlebars.min.js"></script>
-<script src="../javascript/moment.js"></script>
-<script src="../javascript/projects.js"></script>-->
+{% endraw %}
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+<script src="../js/moment.js"></script>
+<script src="../js/projects.js"></script>
 


### PR DESCRIPTION
... images

Jekyll was stripping out the handlebars markers (double braces) from the projects template which was causing the template to be rendered empty. I have surrounded the template in a raw tag so it's now outputted exactly as it is in the html file.

I also added some CSS for the contributor images. I think we should look into putting together our own CSS & layout (Donny said that he was interested in giving this a go) as it's currently a copy of Code4SF--big shoutout to those guys and gals across the bay!