### PR TITLE
Wrap links instead of flowing out of div

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -90,6 +90,9 @@ footer li {
 .contributor-owner img {
   border: 1px solid darkgray;
 }
+.project-info {
+  word-break: break-all;
+}
 .issues {
   list-style-type: none;
   padding: 0 10px;

--- a/projects/index.html
+++ b/projects/index.html
@@ -57,7 +57,7 @@ scripts: ['moment.js','handlebars.min.js','projects.js']
 			<h3>{{name}}</h3>
 			<p>{{description}}</p>
 			<div class="row">
-				<div class="col-md-5">
+				<div class="col-md-5 project-info">
 					{{#if link_url}}
 					<span class="glyphicon glyphicon-home"></span>
 					<a href="{{link_url}}">{{link_url}}</a>


### PR DESCRIPTION
Issue: Currently some links flow out of the div into the Contributors images.
![screenshot 2018-10-17 16 19 44](https://user-images.githubusercontent.com/13262189/47121865-451fbc80-d229-11e8-95d3-f1f6389b9e00.png)

This PR will wrap the link within the div instead. I'm open to suggestion as to how it should be handled. Do you really need to have the full link displayed?
![screenshot 2018-10-17 16 29 32](https://user-images.githubusercontent.com/13262189/47122026-eb6bc200-d229-11e8-9df7-d52a87a0cb45.png)
