### PR TITLE
Remove blog link in header

### DIFF
--- a/_includes/shared/header.html
+++ b/_includes/shared/header.html
@@ -37,7 +37,7 @@
               <li><a href="/projects"><i class="fa fa-tasks"></i> PROJECTS</a></li>
 
 
-              <li><a href="/blog"><i class="fa fa-rss"></i> BLOG</a></li>
+              <!-- TODO: Update blog <li><a href="/blog"><i class="fa fa-rss"></i> BLOG</a></li> -->
             <li><a href="/contact" target="_blank"><i class="fa fa-paper-plane"></i> CONTACT</a></li>
               <li>
                   <!--<p class="btn donate-btn">-->


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Hi there! I came across issue #61 and, after poking around a little, it seemed like the best thing to do is just to remove the link from the header. This preserves the public availability of old blog posts while ensuring no one is being actively directed to the page. It seems like it should be commented out, since it sounds like there's an intention to update the page and reincorporate it. If not, let me know, and I'll fully delete it!

I did notice that the Docker image doesn't include one of the gems that's necessary for actually serving the blog content - should I troubleshoot that so that anyone who forks the repo can set up an image that will allow them to work on the blog template as well?