### PR TITLE
Fix Mary's Twitter link

### DIFF
--- a/_data/core_team.yml
+++ b/_data/core_team.yml
@@ -11,8 +11,8 @@
   headshot: mary_fey_norris.jpg
   bio: Mary is interested in elevating our underserved communities with awareness and accessibility. She has been a Co-Captain of Code for Fresno since 2020 and actively participates with Get Your Refund and Reimaging 911, all of which are Code for America programs. She is also a CfA ReVisioning Spokes Council member. Her motto is,  You must Represent To Reinvent!
   email: mlong101628@gmail.com
-  twitter: 
-  linkedin: https://twitter.com/MaryN7269?t=Dm3D1I7TAwpYhn4FliNgMA&s=09
+  twitter: https://twitter.com/MaryN7269?t=Dm3D1I7TAwpYhn4FliNgMA&s=09
+  linkedin:
 
 - name: Walter Yu
   title: Captain


### PR DESCRIPTION
The LinkedIn button in the core team members section was linking to Mary's Twitter. This links it to the Twitter button instead.