### PR TITLE
Fix markdown rendering in Contact page

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -5,11 +5,11 @@ layout: default
 permalink: /contact/
 ---
 
-###[Email](mailto:hello@codeforsacramento.org) &#124; [Twitter](https://twitter.com/code4sac) &#124; [Meetup](http://www.meetup.com/Code4Sac/)
+#### [Email](mailto:hello@codeforsacramento.org) &#124; [Twitter](https://twitter.com/code4sac) &#124; [Meetup](http://www.meetup.com/Code4Sac/)
 
 <hr />
 
-##Stay up to date
+### Stay up to date
 <!-- Begin MailChimp Signup Form -->
 <link href="//cdn-images.mailchimp.com/embedcode/classic-081711.css" rel="stylesheet" type="text/css">
 <style type="text/css">


### PR DESCRIPTION
The markdown headings using `#` did not not have a space afterwords, thus didn't render correctly. This pull request renders them correctly. It also makes them slightly smaller.