### PR TITLE
Add correct link for the Sac-Tech community slack channel

### DIFF
--- a/_includes/shared/header.html
+++ b/_includes/shared/header.html
@@ -31,7 +31,7 @@
               <ul class="dropdown-menu">
                 <li><a href="http://www.meetup.com/code4sac/" target="_blank"><i class="fa fa-calendar"></i> Show Up</a></li>
                 <li><a href="https://github.com/code4sac/projects" target="_blank"><i class="fa fa-rocket"></i> Start a Project</a></li>
-                <li><a href="https://sac-tech.herokuapp.com/" target="_blank"><i class="fa fa-comments"></i> Discuss #SacTech</a></li>
+                <li><a href="https://sac-tech.com/" target="_blank"><i class="fa fa-comments"></i> Discuss #SacTech</a></li>
               </ul>
             </li>
               <li><a href="/projects"><i class="fa fa-tasks"></i> PROJECTS</a></li>


### PR DESCRIPTION
Resolves #89 Issue - Link is broken for "Discuss #Sac Tech"