### PR TITLE
Resolve Jekyll pagination warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ twitter_username: code4sac
 github_username:  code4sac
 paginate: 5
 paginate_path: "blog/page:num/"
-
+plugins: [jekyll-paginate]
 
 # Build settings
 markdown: kramdown

--- a/_includes/shared/header.html
+++ b/_includes/shared/header.html
@@ -31,7 +31,7 @@
               <ul class="dropdown-menu">
                 <li><a href="http://www.meetup.com/code4sac/" target="_blank"><i class="fa fa-calendar"></i> Show Up</a></li>
                 <li><a href="https://github.com/code4sac/projects" target="_blank"><i class="fa fa-rocket"></i> Start a Project</a></li>
-                <li><a href="https://sac-tech.herokuapp.com/" target="_blank"><i class="fa fa-comments"></i> Discuss #SacTech</a></li>
+                <li><a href="https://sac-tech.com/" target="_blank"><i class="fa fa-comments"></i> Discuss #SacTech</a></li>
               </ul>
             </li>
               <li><a href="/projects"><i class="fa fa-tasks"></i> PROJECTS</a></li>


### PR DESCRIPTION
Resolves deprecation warning when running Jekyll

> Deprecation: You appear to have pagination turned on, but you haven't included the `jekyll-paginate` gem. Ensure you have `plugins: [jekyll-paginate]` in your configuration file.