### PR TITLE
Add support for Apple M1 ARM architecture

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,8 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.18.0)
+    nokogiri (1.15.0-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.0-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -250,6 +252,7 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Run `bundle lock --add-platform aarch64-linux` to resolve error when building the Docker image on Mac.

>  [5/7] RUN bundle install:
#0 0.423 Your bundle only supports platforms ["x86_64-linux"] but your local platform is
#0 0.423 aarch64-linux. Add the current platform to the lockfile with `bundle lock
#0 0.423 --add-platform aarch64-linux` and try again.