### PR TITLE
Remove social media contact info for individual members

### DIFF
--- a/_includes/about/innovators.html
+++ b/_includes/about/innovators.html
@@ -19,18 +19,17 @@
     <img class="img-responsive img-circle" src="/images/headshots/{{ member.headshot }}">
     <h4>{{ member.name }}</h4>
     <h5>{{ member.title }}</h5>
-    <ul class="list-unstyled horizontal-icons text-center">
-      <li><a href="mailto:{{ member.email }}?Subject=Code%20for%20Sacramento" target="_blank"><i class="fa fa-envelope"></i></a></li>
-      <li><a href="https://twitter.com/{{ member.twitter }}"><i class="fa fa-twitter" target="_blank"></i></a></li>
-      <li><a href="{{ member.linkedin }}"><i class="fa fa-linkedin" target="_blank"></i></a></li>
-    </ul>
   </div>
   <div class="col-xs-8">
     <p>{{ member.bio }}</p>
   </div>
 </div>
 {% endfor %}
-
+<div class="row">
+  <div class="col-md-12">
+    <p>Feel free to reach out to anyone on our leadership team by using the contact page or email hello@codeforsacramento.org</p>
+  </div>
+</div>
 <div class="row">
   <div class="col-md-12">
     <h3>Advisory Board</h3>


### PR DESCRIPTION
This change removes the links to social media profiles.

Should we add any other mention on how to contact? This could be linking to the Contact page or by emailing hello@codeforsacramento.org. It might already be clear that Contact Us is in the toolbar, so no other mention is needed.