### PR TITLE
Fix templates not rendering

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -10,14 +10,6 @@ const eleventyConfig = config => {
   config.addPassthroughCopy("css");
   config.addPassthroughCopy("images");
   config.addPassthroughCopy("js");
-  return {
-    htmlTemplateEngine: "njk",
-    templateFormats: ["html", "md"],
-    dir: {
-      includes: "_includes",
-      layouts: "_layouts"
-    }
-  }
 }
 
 module.exports = eleventyConfig

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "url": "git+https://github.com/code4sac/codeforsacramento.org.git"
   },
   "keywords": [],
-	"author": {
-		"name": "Code for Sacramento",
-		"email": "hello@codeforsacramento.org",
-		"url": "https://codeforsacramento.org"
-	},
+  "author": {
+    "name": "Code for Sacramento",
+    "email": "hello@codeforsacramento.org",
+    "url": "https://codeforsacramento.org"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/code4sac/codeforsacramento.org/issues"


### PR DESCRIPTION
This fixes the templates not rendering properly. It now uses the default template engine [Liquid](https://liquidjs.com) for all files (HTML, Markdown) regardless of their file extension.